### PR TITLE
Add rand_gen parameter to new

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,0 +1,29 @@
+##
+## Do not use these
+# Don't worry about /s on regex
+[-RegularExpressions::RequireDotMatchAnything]
+# Don't worry about /m on regex
+[-RegularExpressions::RequireLineBoundaryMatching]
+# Don't worry about /x on regex
+[-RegularExpressions::RequireExtendedFormatting]
+# Don't worry about magic numbers
+[-ValuesAndExpressions::ProhibitMagicNumbers]
+# Don't worry about quotes and noisy strings
+[-ValuesAndExpressions::ProhibitNoisyQuotes]
+# Don't worry about #_ use
+[-BuiltinFunctions::ProhibitUselessTopic]
+# Don't worry about spelling
+[-Documentation::PodSpelling]
+# Disagree with this one
+[-CodeLayout::ProhibitParensWithBuiltins]
+# Don't worry about escaped meta chars
+[-RegularExpressions::ProhibitEscapedMetacharacters]
+# Don't worry about interpolating meta chars
+[-ValuesAndExpressions::RequireInterpolationOfMetachars]
+
+#
+[-Documentation::RequirePodSections]
+
+[Modules::ProhibitExcessMainComplexity]
+max_mccabe = 40
+

--- a/lib/String/Random.pm
+++ b/lib/String/Random.pm
@@ -61,7 +61,7 @@ my %patterns = (
     '\D' => [ @upper, @lower, @punct ],
     '\w' => [ @upper, @lower, @digit, "_" ],
     '\W' => [ grep { $_ ne "_" } @punct ],
-    '\s' => [ " ", "\t" ],                   # Would anything else make sense?
+    '\s' => [ q{ }, "\t" ],                   # Would anything else make sense?
     '\S' => [ @upper, @lower, @digit, @punct ],
 
     # These are translated to their double quoted equivalents.
@@ -143,15 +143,15 @@ my %regch = (
     },
     '*' => sub {
         my ( $self, $ch, $chars, $string ) = @_;
-        unshift( @{$chars}, split( "", "{0,}" ) );
+        unshift( @{$chars}, split( q{}, "{0,}" ) );
     },
     '+' => sub {
         my ( $self, $ch, $chars, $string ) = @_;
-        unshift( @{$chars}, split( "", "{1,}" ) );
+        unshift( @{$chars}, split( q{}, "{1,}" ) );
     },
     '?' => sub {
         my ( $self, $ch, $chars, $string ) = @_;
-        unshift( @{$chars}, split( "", "{0,1}" ) );
+        unshift( @{$chars}, split( q{}, "{0,1}" ) );
     },
     '{' => sub {
         my ( $self, $ch, $chars, $string ) = @_;
@@ -228,7 +228,7 @@ sub randregex {
     while ( defined( my $pattern = shift ) ) {
         my $ch;
         my @string = ();
-        my $string = '';
+        my $string = q{};
 
         # Split the characters in the pattern
         # up into a list for easier parsing.
@@ -256,7 +256,7 @@ sub randregex {
         push( @strings, $string );
     }
 
-    return wantarray ? @strings : join( "", @strings );
+    return wantarray ? @strings : join( q{}, @strings );
 }
 
 # For compatibility with an ancient version, please ignore...
@@ -274,7 +274,7 @@ sub randpattern {
     my @strings = ();
 
     while ( defined( my $pattern = shift ) ) {
-        my $string = '';
+        my $string = q{};
 
         for my $ch ( split( //, $pattern ) ) {
             if ( defined( $self->{$ch} ) ) {
@@ -288,7 +288,7 @@ sub randpattern {
         push( @strings, $string );
     }
 
-    return wantarray ? @strings : join( "", @strings );
+    return wantarray ? @strings : join( q{}, @strings );
 }
 
 sub random_regex {

--- a/lib/String/Random.pm
+++ b/lib/String/Random.pm
@@ -35,10 +35,10 @@ our $VERSION   = '0.26';
 my @upper  = ( "A" .. "Z" );
 my @lower  = ( "a" .. "z" );
 my @digit  = ( "0" .. "9" );
-my @punct  = map { chr($_); } ( 33 .. 47, 58 .. 64, 91 .. 96, 123 .. 126 );
+my @punct  = map { chr } ( 33 .. 47, 58 .. 64, 91 .. 96, 123 .. 126 );
 my @any    = ( @upper, @lower, @digit, @punct );
 my @salt   = ( @upper, @lower, @digit, ".", "/" );
-my @binary = map { chr($_) } ( 0 .. 255 );
+my @binary = map { chr } ( 0 .. 255 );
 
 # What's important is how they relate to the pattern characters.
 # These are the old patterns for randpattern/random_string.

--- a/lib/String/Random.pm
+++ b/lib/String/Random.pm
@@ -23,9 +23,9 @@ use parent qw(Exporter);
 our %EXPORT_TAGS = (
     'all' => [
         qw(
-          &random_string
-          &random_regex
-          )
+            &random_string
+            &random_regex
+            )
     ]
 );
 our @EXPORT_OK = ( @{ $EXPORT_TAGS{'all'} } );
@@ -134,7 +134,7 @@ our %regch = (
             }
             else {
                 carp "'$ch' will be treated literally inside []"
-                  if ( $ch =~ /\W/ );
+                    if ( $ch =~ /\W/ );
                 push( @tmp, $ch );
             }
         }
@@ -156,7 +156,7 @@ our %regch = (
     '{' => sub {
         my ( $self, $ch, $chars, $string ) = @_;
         my $closed;
-      CLOSED:
+    CLOSED:
         for my $c (@$chars) {
             if ( $c eq "}" ) {
                 $closed = 1;
@@ -278,8 +278,8 @@ sub randpattern {
 
         for my $ch ( split( //, $pattern ) ) {
             if ( defined( $self->{$ch} ) ) {
-                $string .=
-                  $self->{$ch}->[ int( rand( scalar( @{ $self->{$ch} } ) ) ) ];
+                $string .= $self->{$ch}
+                    ->[ int( rand( scalar( @{ $self->{$ch} } ) ) ) ];
             }
             else {
                 croak qq(Unknown pattern character "$ch"!);

--- a/lib/String/Random.pm
+++ b/lib/String/Random.pm
@@ -186,9 +186,9 @@ my %regch = (
                 }
             }
             if ($tmp) {
-                my $last = $string->[-1];
+                my $prev_ch = $string->[-1];
 
-                push @$string, ( ($last) x ( $tmp - 1 ) );
+                push @$string, ( ($prev_ch) x ( $tmp - 1 ) );
             }
             else {
                 pop( @{$string} );

--- a/lib/String/Random.pm
+++ b/lib/String/Random.pm
@@ -117,7 +117,7 @@ our %regch = (
         my @tmp;
         while ( defined( $ch = shift( @{$chars} ) ) && ( $ch ne "]" ) ) {
             if ( ( $ch eq "-" ) && @{$chars} && @tmp ) {
-                my $begin_ch = $tmp[$#tmp];
+                my $begin_ch = $tmp[-1];
                 $ch = shift( @{$chars} );
                 my $key = "$begin_ch-$ch";
                 if ( defined( $parsed_range_patterns{$key} ) ) {

--- a/lib/String/Random.pm
+++ b/lib/String/Random.pm
@@ -171,8 +171,8 @@ my %regch = (
             }
             if ( $tmp =~ /,/ ) {
                 if ( my ( $min, $max ) = $tmp =~ /^(\d*),(\d*)$/ ) {
-                    $min = 0 if ( !length($min) );
-                    $max = $self->{'_max'} if ( !length($max) );
+                    if ( !length($min) ) { $min = 0 }
+                    if ( !length($max) ) { $max = $self->{'_max'} }
                     croak "bad range {$tmp}" if ( $min > $max );
                     if ( $min == $max ) {
                         $tmp = $min;
@@ -207,7 +207,7 @@ sub new {
     my $self;
     $self = {%old_patterns};    # makes $self refer to a copy of %old_patterns
     my %args = ();
-    %args = @args if (@args);
+    if (@args) { %args = @args }
     if ( defined( $args{'max'} ) ) {
         $self->{'_max'} = $args{'max'};
     }

--- a/lib/String/Random.pm
+++ b/lib/String/Random.pm
@@ -178,7 +178,7 @@ my %regch = (
                         $tmp = $min;
                     }
                     else {
-                        $tmp = $min + int( rand( $max - $min + 1 ) );
+                        $tmp = $min + $self->{'_rand'}( $max - $min + 1 );
                     }
                 }
                 else {
@@ -201,6 +201,12 @@ my %regch = (
     },
 );
 
+# Default rand function
+sub _rand {
+    my ($max) = @_;
+    return int rand $max;
+}
+
 sub new {
     my ( $proto, @args ) = @_;
     my $class = ref($proto) || $proto;
@@ -213,6 +219,12 @@ sub new {
     }
     else {
         $self->{'_max'} = 10;
+    }
+    if ( defined( $args{'rand_gen'} ) ) {
+        $self->{'_rand'} = $args{'rand_gen'};
+    }
+    else {
+        $self->{'_rand'} = sub { _rand(@_) }
     }
     return bless( $self, $class );
 }
@@ -250,7 +262,7 @@ sub randregex {
         }
 
         foreach my $ch (@string) {
-            $string .= $ch->[ int( rand( scalar( @{$ch} ) ) ) ];
+            $string .= $ch->[ $self->{'_rand'}( scalar( @{$ch} ) ) ];
         }
 
         push( @strings, $string );
@@ -279,7 +291,7 @@ sub randpattern {
         for my $ch ( split( //, $pattern ) ) {
             if ( defined( $self->{$ch} ) ) {
                 $string .= $self->{$ch}
-                    ->[ int( rand( scalar( @{ $self->{$ch} } ) ) ) ];
+                    ->[ $self->{'_rand'}( scalar( @{ $self->{$ch} } ) ) ];
             }
             else {
                 croak qq(Unknown pattern character "$ch"!);
@@ -396,11 +408,23 @@ for adding patterns.
 
 =item new max =E<gt> I<number>
 
+=item new rand_gen =E<gt> I<sub>
+
 Create a new String::Random object.
 
 Optionally a parameter C<max> can be included to specify the maximum number
 of characters to return for C<*> and other regular expression patterns that
 do not return a fixed number of characters.
+
+Optionally a parameter C<rand_gen> can be included to specify a subroutine
+coderef for generating the random numbers used in this module. The coderef
+must accept one argument C<max> and return an integer between 0 and C<max - 1>.
+The default rand_gen coderef is
+
+ sub {
+     my ($max) = @_;
+     return int rand $max;
+ }
 
 =item randpattern LIST
 

--- a/lib/String/Random.pm
+++ b/lib/String/Random.pm
@@ -293,7 +293,7 @@ sub randpattern {
 
 sub random_regex {
     my (@args) = @_;
-    my $foo = new String::Random;
+    my $foo = String::Random->new;
     return $foo->randregex(@args);
 }
 

--- a/lib/String/Random.pm
+++ b/lib/String/Random.pm
@@ -32,17 +32,17 @@ our @EXPORT_OK = ( @{ $EXPORT_TAGS{'all'} } );
 our $VERSION   = '0.26';
 
 # These are the various character sets.
-our @upper  = ( "A" .. "Z" );
-our @lower  = ( "a" .. "z" );
-our @digit  = ( "0" .. "9" );
-our @punct  = map { chr($_); } ( 33 .. 47, 58 .. 64, 91 .. 96, 123 .. 126 );
-our @any    = ( @upper, @lower, @digit, @punct );
-our @salt   = ( @upper, @lower, @digit, ".", "/" );
-our @binary = map { chr($_) } ( 0 .. 255 );
+my @upper  = ( "A" .. "Z" );
+my @lower  = ( "a" .. "z" );
+my @digit  = ( "0" .. "9" );
+my @punct  = map { chr($_); } ( 33 .. 47, 58 .. 64, 91 .. 96, 123 .. 126 );
+my @any    = ( @upper, @lower, @digit, @punct );
+my @salt   = ( @upper, @lower, @digit, ".", "/" );
+my @binary = map { chr($_) } ( 0 .. 255 );
 
 # What's important is how they relate to the pattern characters.
 # These are the old patterns for randpattern/random_string.
-our %old_patterns = (
+my %old_patterns = (
     'C' => [@upper],
     'c' => [@lower],
     'n' => [@digit],
@@ -53,7 +53,7 @@ our %old_patterns = (
 );
 
 # These are the regex-based patterns.
-our %patterns = (
+my %patterns = (
 
     # These are the regex-equivalents.
     '.'  => [@any],
@@ -74,10 +74,10 @@ our %patterns = (
 );
 
 # This is used for cache of parsed range patterns in %regch
-our %parsed_range_patterns = ();
+my %parsed_range_patterns = ();
 
 # These characters are treated specially in randregex().
-our %regch = (
+my %regch = (
     "\\" => sub {
         my ( $self, $ch, $chars, $string ) = @_;
         if ( @{$chars} ) {

--- a/lib/String/Random.pm
+++ b/lib/String/Random.pm
@@ -32,12 +32,12 @@ our @EXPORT_OK = ( @{ $EXPORT_TAGS{'all'} } );
 our $VERSION   = '0.26';
 
 # These are the various character sets.
-my @upper  = ( "A" .. "Z" );
-my @lower  = ( "a" .. "z" );
-my @digit  = ( "0" .. "9" );
+my @upper  = ( 'A' .. 'Z' );
+my @lower  = ( 'a' .. 'z' );
+my @digit  = ( '0' .. '9' );
 my @punct  = map { chr } ( 33 .. 47, 58 .. 64, 91 .. 96, 123 .. 126 );
 my @any    = ( @upper, @lower, @digit, @punct );
-my @salt   = ( @upper, @lower, @digit, ".", "/" );
+my @salt   = ( @upper, @lower, @digit, '.', '/' );
 my @binary = map { chr } ( 0 .. 255 );
 
 # What's important is how they relate to the pattern characters.
@@ -59,8 +59,8 @@ my %patterns = (
     '.'  => [@any],
     '\d' => [@digit],
     '\D' => [ @upper, @lower, @punct ],
-    '\w' => [ @upper, @lower, @digit, "_" ],
-    '\W' => [ grep { $_ ne "_" } @punct ],
+    '\w' => [ @upper, @lower, @digit, '_' ],
+    '\W' => [ grep { $_ ne '_' } @punct ],
     '\s' => [ q{ }, "\t" ],                   # Would anything else make sense?
     '\S' => [ @upper, @lower, @digit, @punct ],
 
@@ -78,11 +78,11 @@ my %parsed_range_patterns = ();
 
 # These characters are treated specially in randregex().
 my %regch = (
-    "\\" => sub {
+    '\\' => sub {
         my ( $self, $ch, $chars, $string ) = @_;
         if ( @{$chars} ) {
             my $tmp = shift( @{$chars} );
-            if ( $tmp eq "x" ) {
+            if ( $tmp eq 'x' ) {
 
                 # This is supposed to be a number in hex, so
                 # there had better be at least 2 characters left.
@@ -90,7 +90,7 @@ my %regch = (
                 push( @{$string}, [ chr( hex($tmp) ) ] );
             }
             elsif ( $tmp =~ /[0-7]/ ) {
-                carp "octal parsing not implemented.  treating literally.";
+                carp 'octal parsing not implemented.  treating literally.';
                 push( @{$string}, [$tmp] );
             }
             elsif ( defined( $patterns{"\\$tmp"} ) ) {
@@ -105,7 +105,7 @@ my %regch = (
             }
         }
         else {
-            croak "regex not terminated";
+            croak 'regex not terminated';
         }
     },
     '.' => sub {
@@ -115,8 +115,8 @@ my %regch = (
     '[' => sub {
         my ( $self, $ch, $chars, $string ) = @_;
         my @tmp;
-        while ( defined( $ch = shift( @{$chars} ) ) && ( $ch ne "]" ) ) {
-            if ( ( $ch eq "-" ) && @{$chars} && @tmp ) {
+        while ( defined( $ch = shift( @{$chars} ) ) && ( $ch ne ']' ) ) {
+            if ( ( $ch eq '-' ) && @{$chars} && @tmp ) {
                 my $begin_ch = $tmp[-1];
                 $ch = shift( @{$chars} );
                 my $key = "$begin_ch-$ch";
@@ -138,34 +138,34 @@ my %regch = (
                 push( @tmp, $ch );
             }
         }
-        croak "unmatched []" if ( $ch ne "]" );
+        croak 'unmatched []' if ( $ch ne ']' );
         push( @{$string}, \@tmp );
     },
     '*' => sub {
         my ( $self, $ch, $chars, $string ) = @_;
-        unshift( @{$chars}, split( //, "{0,}" ) );
+        unshift( @{$chars}, split( //, '{0,}' ) );
     },
     '+' => sub {
         my ( $self, $ch, $chars, $string ) = @_;
-        unshift( @{$chars}, split( //, "{1,}" ) );
+        unshift( @{$chars}, split( //, '{1,}' ) );
     },
     '?' => sub {
         my ( $self, $ch, $chars, $string ) = @_;
-        unshift( @{$chars}, split( //, "{0,1}" ) );
+        unshift( @{$chars}, split( //, '{0,1}' ) );
     },
     '{' => sub {
         my ( $self, $ch, $chars, $string ) = @_;
         my $closed;
     CLOSED:
         for my $c (@{$chars}) {
-            if ( $c eq "}" ) {
+            if ( $c eq '}' ) {
                 $closed = 1;
                 last CLOSED;
             }
         }
         if ($closed) {
             my $tmp;
-            while ( defined( $ch = shift( @{$chars} ) ) && ( $ch ne "}" ) ) {
+            while ( defined( $ch = shift( @{$chars} ) ) && ( $ch ne '}' ) ) {
                 croak "'$ch' inside {} not supported" if ( $ch !~ /[\d,]/ );
                 $tmp .= $ch;
             }
@@ -221,7 +221,7 @@ sub new {
 # argument, or the strings concatenated when used in a scalar context.
 sub randregex {
     my $self = shift;
-    croak "called without a reference" if ( !ref($self) );
+    croak 'called without a reference' if ( !ref($self) );
 
     my @strings = ();
 
@@ -262,14 +262,14 @@ sub randregex {
 # For compatibility with an ancient version, please ignore...
 sub from_pattern {
     my ( $self, @args ) = @_;
-    croak "called without a reference" if ( !ref($self) );
+    croak 'called without a reference' if ( !ref($self) );
 
     return $self->randpattern(@args);
 }
 
 sub randpattern {
     my $self = shift;
-    croak "called without a reference" if ( !ref($self) );
+    croak 'called without a reference' if ( !ref($self) );
 
     my @strings = ();
 

--- a/lib/String/Random.pm
+++ b/lib/String/Random.pm
@@ -35,10 +35,10 @@ our $VERSION   = '0.26';
 my @upper  = ( 'A' .. 'Z' );
 my @lower  = ( 'a' .. 'z' );
 my @digit  = ( '0' .. '9' );
-my @punct  = map { chr } ( 33 .. 47, 58 .. 64, 91 .. 96, 123 .. 126 );
+my @punct  = map {chr} ( 33 .. 47, 58 .. 64, 91 .. 96, 123 .. 126 );
 my @any    = ( @upper, @lower, @digit, @punct );
 my @salt   = ( @upper, @lower, @digit, '.', '/' );
-my @binary = map { chr } ( 0 .. 255 );
+my @binary = map {chr} ( 0 .. 255 );
 
 # What's important is how they relate to the pattern characters.
 # These are the old patterns for randpattern/random_string.
@@ -60,8 +60,8 @@ my %patterns = (
     '\d' => [@digit],
     '\D' => [ @upper, @lower, @punct ],
     '\w' => [ @upper, @lower, @digit, '_' ],
-    '\W' => [ grep { $_ ne '_' } @punct ],
-    '\s' => [ q{ }, "\t" ],                   # Would anything else make sense?
+    '\W' => [ grep  { $_ ne '_' } @punct ],
+    '\s' => [ q{ }, "\t" ],                  # Would anything else make sense?
     '\S' => [ @upper, @lower, @digit, @punct ],
 
     # These are translated to their double quoted equivalents.
@@ -157,7 +157,7 @@ my %regch = (
         my ( $self, $ch, $chars, $string ) = @_;
         my $closed;
     CLOSED:
-        for my $c (@{$chars}) {
+        for my $c ( @{$chars} ) {
             if ( $c eq '}' ) {
                 $closed = 1;
                 last CLOSED;

--- a/lib/String/Random.pm
+++ b/lib/String/Random.pm
@@ -251,7 +251,7 @@ sub randregex {
             }
         }
 
-        foreach $ch (@string) {
+        foreach my $ch (@string) {
             $string .= $ch->[ int( rand( scalar( @{$ch} ) ) ) ];
         }
 

--- a/lib/String/Random.pm
+++ b/lib/String/Random.pm
@@ -18,9 +18,8 @@ use strict;
 use warnings;
 
 use Carp;
-use Exporter ();
+use parent qw(Exporter);
 
-our @ISA         = qw(Exporter);
 our %EXPORT_TAGS = (
     'all' => [
         qw(
@@ -30,7 +29,6 @@ our %EXPORT_TAGS = (
     ]
 );
 our @EXPORT_OK = ( @{ $EXPORT_TAGS{'all'} } );
-our @EXPORT    = ();
 our $VERSION   = '0.26';
 
 # These are the various character sets.

--- a/lib/String/Random.pm
+++ b/lib/String/Random.pm
@@ -143,15 +143,15 @@ my %regch = (
     },
     '*' => sub {
         my ( $self, $ch, $chars, $string ) = @_;
-        unshift( @{$chars}, split( q{}, "{0,}" ) );
+        unshift( @{$chars}, split( //, "{0,}" ) );
     },
     '+' => sub {
         my ( $self, $ch, $chars, $string ) = @_;
-        unshift( @{$chars}, split( q{}, "{1,}" ) );
+        unshift( @{$chars}, split( //, "{1,}" ) );
     },
     '?' => sub {
         my ( $self, $ch, $chars, $string ) = @_;
-        unshift( @{$chars}, split( q{}, "{0,1}" ) );
+        unshift( @{$chars}, split( //, "{0,1}" ) );
     },
     '{' => sub {
         my ( $self, $ch, $chars, $string ) = @_;

--- a/lib/String/Random.pm
+++ b/lib/String/Random.pm
@@ -202,12 +202,12 @@ our %regch = (
 );
 
 sub new {
-    my $proto = shift;
+    my ( $proto, @args ) = @_;
     my $class = ref($proto) || $proto;
     my $self;
     $self = {%old_patterns};    # makes $self refer to a copy of %old_patterns
     my %args = ();
-    %args = @_ if (@_);
+    %args = @args if (@args);
     if ( defined( $args{'max'} ) ) {
         $self->{'_max'} = $args{'max'};
     }
@@ -261,10 +261,10 @@ sub randregex {
 
 # For compatibility with an ancient version, please ignore...
 sub from_pattern {
-    my $self = shift;
+    my ( $self, @args ) = @_;
     croak "called without a reference" if ( !ref($self) );
 
-    return $self->randpattern(@_);
+    return $self->randpattern(@args);
 }
 
 sub randpattern {
@@ -292,8 +292,9 @@ sub randpattern {
 }
 
 sub random_regex {
+    my (@args) = @_;
     my $foo = new String::Random;
-    return $foo->randregex(@_);
+    return $foo->randregex(@args);
 }
 
 sub random_string {

--- a/lib/String/Random.pm
+++ b/lib/String/Random.pm
@@ -157,7 +157,7 @@ my %regch = (
         my ( $self, $ch, $chars, $string ) = @_;
         my $closed;
     CLOSED:
-        for my $c (@$chars) {
+        for my $c (@{$chars}) {
             if ( $c eq "}" ) {
                 $closed = 1;
                 last CLOSED;
@@ -188,7 +188,7 @@ my %regch = (
             if ($tmp) {
                 my $prev_ch = $string->[-1];
 
-                push @$string, ( ($prev_ch) x ( $tmp - 1 ) );
+                push @{$string}, ( ($prev_ch) x ( $tmp - 1 ) );
             }
             else {
                 pop( @{$string} );

--- a/t/07_rand_gen.t
+++ b/t/07_rand_gen.t
@@ -1,0 +1,33 @@
+use strict;
+use warnings;
+
+use Test::More tests => (6);
+
+# 1: Make sure we can load the module
+BEGIN { use_ok('String::Random'); }
+
+# 2: Make sure we can create a new object with rand_gen argument
+my $foo = String::Random->new(
+    rand_gen => sub {
+        my ($max) = @_;
+        return int( $max - 1 );
+    }
+);
+ok( defined($foo), "new()" );
+
+# 3: Make sure _rand is defined
+ok( defined( $foo->{'_rand'} ), "_rand defined" );
+
+# 4: Make sure _rand returns value as expected
+is( $foo->{'_rand'}(10), 9 )
+    or diag "_rand function returned wrong value";
+
+# 5: check randpattern with rand_gen function
+my $cCn = $foo->randpattern("cCn");
+is( $cCn, 'zZ9', "randpattern() with rand_gen" );
+
+# 6: check randregex with rand_gen function
+$cCn = $foo->randregex("[a-z][A-Z][0-9]");
+is( $cCn, 'zZ9', "randregex() with rand_gen" );
+
+# vi: set ai et syntax=perl:


### PR DESCRIPTION
This PR, based on the perlcritic_cleanup PR, adds a rand_gen parameter to new that allows the user to specify a rand function to use instead of Perl's built in rand.

Include code, documentation, and tests.